### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A Model Context Protocol (MCP) server that provides Formula One racing data. This package exposes various tools for querying F1 data including event schedules, driver information, telemetry data, and race results.
 
+<a href="https://glama.ai/mcp/servers/@Machine-To-Machine/f1-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Machine-To-Machine/f1-mcp-server/badge" alt="Formula One Server (Python) MCP server" />
+</a>
+
 ## Features
 
 - **Event Schedule**: Access the complete F1 race calendar for any season


### PR DESCRIPTION
This PR adds a badge for the [Formula One MCP Server (Python)](https://glama.ai/mcp/servers/@Machine-To-Machine/f1-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Machine-To-Machine/f1-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Machine-To-Machine/f1-mcp-server/badge" alt="Formula One Server (Python) MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.